### PR TITLE
Tune Gradle test logging verbosity

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
 import org.jetbrains.grammarkit.tasks.GenerateLexerTask
@@ -133,6 +135,19 @@ kover {
 tasks {
     wrapper {
         gradleVersion = providers.gradleProperty("gradleVersion").get()
+    }
+
+    withType<Test>().configureEach {
+        testLogging {
+            events = setOf(
+                TestLogEvent.SKIPPED,
+                TestLogEvent.FAILED,
+            )
+            exceptionFormat = TestExceptionFormat.FULL
+            showCauses = true
+            showExceptions = true
+            showStackTraces = false
+        }
     }
 
     publishPlugin {


### PR DESCRIPTION
### Motivation
- Reduce noisy test logs by omitting passed test events and disabling stacktrace dumps while keeping useful failure information.
- Keep CI and local output concise so failures remain visible without streaming all stdout/stderr into test logs.

### Description
- Added imports and configured `withType<Test>().configureEach` in `build.gradle.kts` to centralize test logging settings.
- Removed `TestLogEvent.PASSED` and now only log `TestLogEvent.SKIPPED` and `TestLogEvent.FAILED` events.
- Kept `exceptionFormat = TestExceptionFormat.FULL` with `showCauses` and `showExceptions` enabled and set `showStackTraces = false` to hide stack traces.

### Testing
- Ran `./gradlew check` to exercise the test suite.
- The build executed 114 tests with 7 failures and the `:test` task failed.
- Failures were in LSP/Expert download tests that assert executables are downloaded within 1m and failed due to network/unavailable downloads.
- Exception details were still reported in test output despite stack traces being disabled.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950f95024a0832d9544b622a9c3e695)